### PR TITLE
Fixed AddEntry method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ TestResults
 *.opensdf
 /.vs/dtool/v15
 /Backup
+.vs

--- a/VSDebugCoreLib/Console/HistoryBuffer.cs
+++ b/VSDebugCoreLib/Console/HistoryBuffer.cs
@@ -73,21 +73,21 @@ namespace VSDebugCoreLib.Console
             currentReturned = false;
             if (-1 != index)
             {
-                // The index is in the buffer, so set the it as the current one
-                // and return.
-                currentPosition = index;
-                return;
+                // The index is in the buffer, remove the entry from current index
+                // and add it at the end of the buffer
+                buffer.RemoveAt(index);
             }
-            // The entry is not in the buffer, so we have to add it. 
-            // Before add the new item we have to check if the buffer is over
-            // capacity.
-            if (buffer.Count == buffer.Capacity)
+            else if (buffer.Count == buffer.Capacity)
             {
+                // Before add the item we have to check if the buffer is over
+                // capacity.
                 // Remove the first element in the buffer.
                 buffer.RemoveAt(0);
             }
+
             // Add the new entry at the end of the buffer.
             buffer.Add(entry);
+
             // Set the current position at the end of the buffer.
             currentPosition = buffer.Count - 1;
         }


### PR DESCRIPTION
The AddEntry method should add the already existing entries at the end of the buffer, not just update the currentPosition index.
Also added .vs to gitignore because i was unable to commit changes. 
Found this here: https://github.com/github/gitignore/blob/master/VisualStudio.gitignore