### PR TITLE
Better argument parsing

### DIFF
--- a/VSDebugCoreLib/Commands/BaseCommand.cs
+++ b/VSDebugCoreLib/Commands/BaseCommand.cs
@@ -1,4 +1,6 @@
-﻿namespace VSDebugCoreLib.Commands
+using System.Collections.Generic;
+
+namespace VSDebugCoreLib.Commands
 {
     public class BaseCommand : IConsoleCommand
     {
@@ -6,6 +8,7 @@
         protected string CommandDescription;
         protected string CommandHelpString;
         protected ECommandStatus CommandStatusFlag;
+        protected string[] CommandArguments;
 
         public BaseCommand(VSDebugContext context, int cmdId, string strId)
         {
@@ -24,7 +27,7 @@
         public string CommandInfo => CommandDescription;
         public virtual ECommandStatus CommandStatus => CommandStatusFlag;
 
-        public virtual void Execute(string text)
+        public virtual void Execute(string[] args)
         {
         }
     }

--- a/VSDebugCoreLib/Commands/Core/Alias.cs
+++ b/VSDebugCoreLib/Commands/Core/Alias.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using VSDebugCoreLib.Utils;
 
 namespace VSDebugCoreLib.Commands.Core
 {
@@ -11,7 +12,7 @@ namespace VSDebugCoreLib.Commands.Core
 
             CommandHelpString = "Syntax: <" + CommandString + ">" + " <add/del/list> <name> <string>\n" +
                                 "\tEX: " + CommandString +
-                                " add imgcopy memcpy img1.data img0.data img0.height * img0.stride \n" +
+                                " add imgcopy memcpy img1.data img0.data \"img0.height * img0.stride\" \n" +
                                 "\tEX: " + CommandString + " del imgcopy\n" +
                                 "\tEX: " + CommandString + " list\n";
 
@@ -20,111 +21,113 @@ namespace VSDebugCoreLib.Commands.Core
 
         public override ECommandStatus CommandStatus => CommandStatusFlag;
 
-        public override void Execute(string text)
+        public override void Execute(string[] args)
         {
-            base.Execute(text);
+            base.Execute(args);
 
-            char[] sp = {' ', '\t'};
-            var argv = text.Split(sp, 3, StringSplitOptions.RemoveEmptyEntries);
-            var bRes = false;
-            string alias = null;
-            string value = null;
-
-            switch (argv.Length)
+            if (0 == args.Length)
             {
-                case 0:
+                Context.CONSOLE.Write(CommandHelp);
+            }
+            else if (1 == args.Length)
+            {
+                if ("list" == args[0])
+                {
+                    if (Context.Settings.Alias.AliasList.Values.Count > 0)
+                    {
+                        Context.CONSOLE.WriteSeparator();
+
+                        foreach (var item in Context.Settings.Alias.AliasList.Values)
+                        {
+                            var text = string.Format("{0,15}\t{1}", item.Alias, item.Value);
+                            foreach (var arg in item.Arguments)
+                            {
+                                if (arg.Contains(" ") || arg.Contains("\t"))
+                                {
+                                    text += string.Format(" \"{0}\"", arg);
+                                }
+                                else
+                                {
+                                    text += string.Format(" {0}", arg);
+                                }
+                            }
+                            Context.CONSOLE.Write(text);
+                        }
+                    }
+                    else
+                    {
+                        Context.CONSOLE.WriteSeparator();
+                        Context.CONSOLE.Write("no aliases available");
+
+                    }
+                }
+                else
+                {
                     Context.CONSOLE.Write(CommandHelp);
-                    return;
-
-                case 1:
+                }
+            }
+            else if (2 == args.Length)
+            {
+                if ("del" == args[0])
                 {
-                    if ("list" == argv[0])
+                    var alias = args[1];
+                    if (null != Context.Settings.Alias.FindAlias(alias))
                     {
-                        if (Context.Settings.Alias.AliasList.Values.Count > 0)
-                        {
-                            Context.CONSOLE.WriteSeparator();
-
-                            foreach (var item in Context.Settings.Alias.AliasList.Values)
-                                Context.CONSOLE.Write(string.Format("{0,15}\t{1}", item.Alias, item.Value));
-                        }
+                        if (Context.Settings.Alias.DelAlias(alias))
+                            Context.CONSOLE.Write("Deleted alias: " + alias + ".");
                     }
                     else
                     {
-                        Context.CONSOLE.Write(CommandHelp);
+                        Context.CONSOLE.Write("Alias: " + alias + " not found.");
                     }
                 }
-                    return;
-
-                case 2:
+                else
                 {
-                    alias = argv[1];
+                    Context.CONSOLE.Write(CommandHelp);
+                }
+            }
+            else
+            {
+                var action = args[0];
+                var alias = args[1];
 
-                    if ("del" == argv[0])
+                var aliasCmd = args[2];
+                var aliasArgs = MiscHelpers.ShiftArray(args, 3);
+
+                if ("add" == action)
+                {
+                    // prevent command hiding
+                    if (null != Context.CONSOLE.FindCommand(alias))
                     {
-                        if (null != Context.Settings.Alias.FindAlias(alias))
-                        {
-                            bRes = Context.Settings.Alias.DelAlias(alias);
-                            if (bRes)
-                                Context.CONSOLE.Write("Deleted alias: " + alias + ".");
-                        }
-                        else
-                        {
-                            Context.CONSOLE.Write("Alias: " + alias + " not found.");
-                        }
+                        Context.CONSOLE.Write("Unable to alias: " + alias + "!");
+                        return;
+                    }
+
+                    if (null == Context.CONSOLE.FindCommand(aliasCmd))
+                    {
+                        Context.CONSOLE.Write("Command: " + "<" + aliasCmd + ">" + " is not valid.");
+                        return;
+                    }
+
+                    if (null != Context.Settings.Alias.FindAlias(alias))
+                    {
+                        Context.CONSOLE.Write("Alias: " + alias + " is already defined.");
+                        return;
+                    }
+
+                    if (Context.Settings.Alias.AddAlias(alias, aliasCmd, aliasArgs))
+                    {
+                        Context.CONSOLE.Write("Added alias: " + alias + ".");
                     }
                     else
                     {
-                        Context.CONSOLE.Write(CommandHelp);
+                        Context.CONSOLE.Write("Unable to alias: " + alias + "!");
                     }
                 }
-                    return;
-
-                case 3:
+                else
                 {
-                    alias = argv[1];
-                    value = argv[2];
-
-                    var aliasargv = value.Split(sp, 2, StringSplitOptions.RemoveEmptyEntries);
-                    var aliascmd = aliasargv[0];
-
-                    if ("add" == argv[0])
-                    {
-                        // prevent command hiding
-                        if (null != Context.CONSOLE.FindCommand(alias))
-                        {
-                            Context.CONSOLE.Write("Unable to alias: " + alias + "!");
-                            break;
-                        }
-
-                        if (null == Context.CONSOLE.FindCommand(aliascmd))
-                        {
-                            bRes = false;
-                            Context.CONSOLE.Write("Command: " + "<" + aliascmd + ">" + " is not valid.");
-                            break;
-                        }
-
-                        if (null == Context.Settings.Alias.FindAlias(alias))
-                        {
-                            bRes = Context.Settings.Alias.AddAlias(alias, value);
-                        }
-                        else
-                        {
-                            bRes = false;
-                            Context.CONSOLE.Write("Alias: " + alias + " is already defined.");
-                            break;
-                        }
-
-                        if (bRes)
-                            Context.CONSOLE.Write("Added alias: " + alias + ".");
-                        else
-                            Context.CONSOLE.Write("Unable to alias: " + alias + "!");
-                    }
-                    else
-                    {
-                        Context.CONSOLE.Write(CommandHelp);
-                    }
+                    Context.CONSOLE.Write(CommandHelp);
                 }
-                    return;
             }
         }
     }

--- a/VSDebugCoreLib/Commands/IConsoleCommand.cs
+++ b/VSDebugCoreLib/Commands/IConsoleCommand.cs
@@ -1,4 +1,4 @@
-﻿namespace VSDebugCoreLib.Commands
+namespace VSDebugCoreLib.Commands
 {
     /// <summary>
     ///     Command status
@@ -38,6 +38,6 @@
         /// <summary>
         ///     Execute function
         /// </summary>
-        void Execute(string text);
+        void Execute(string[] args);
     }
 }

--- a/VSDebugCoreLib/Commands/Memory/DumpMem.cs
+++ b/VSDebugCoreLib/Commands/Memory/DumpMem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.IO;
 using VSDebugCoreLib.Utils;
@@ -42,25 +42,20 @@ namespace VSDebugCoreLib.Commands.Memory
             }
         }
 
-        public override void Execute(string text)
+        public override void Execute(string[] args)
         {
-            base.Execute(text);
+            base.Execute(args);
 
-            char[] sp = {' ', '\t'};
-            var argv = text.Split(sp, 2, StringSplitOptions.RemoveEmptyEntries);
-
-            if (argv.Length < 2)
+            if (args.Length < 2)
             {
                 Context.CONSOLE.Write(CommandHelp);
                 return;
             }
 
             // check for optional parameters
-            var strArgParam = argv[0];
-            var strArgFile = "";
-            var strArgSource = "";
-            var strArgSize = "";
+            var strArgParam = args[0];
             var chrFlag = '\0';
+            var paramShift = 0;
 
             if ('-' == strArgParam[0])
             {
@@ -68,6 +63,7 @@ namespace VSDebugCoreLib.Commands.Memory
                 if (2 == strArgParam.Length)
                 {
                     chrFlag = char.ToLower(strArgParam[1]);
+                    paramShift += 1;
                 }
                 else
                 {
@@ -76,18 +72,16 @@ namespace VSDebugCoreLib.Commands.Memory
                 }
             }
 
-            var reqNArg = '\0' == chrFlag ? 3 : 4;
-            argv = text.Split(sp, reqNArg, StringSplitOptions.RemoveEmptyEntries);
-
-            if (argv.Length != reqNArg)
+            if (args.Length != 3 + paramShift)
             {
                 Context.CONSOLE.Write(CommandHelp);
                 return;
             }
 
-            strArgFile = '\0' == chrFlag ? argv[0] : argv[1];
-            strArgSource = '\0' == chrFlag ? argv[1] : argv[2];
-            strArgSize = '\0' == chrFlag ? argv[2] : argv[3];
+
+            var strArgFile = args[0 + paramShift];
+            var strArgSource = args[2 + paramShift];
+            var strArgSize = args[1 + paramShift];
 
             // get file path
             var strPath = Path.GetDirectoryName(strArgFile);

--- a/VSDebugCoreLib/Commands/Memory/LoadMem.cs
+++ b/VSDebugCoreLib/Commands/Memory/LoadMem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.IO;
 using VSDebugCoreLib.Utils;
@@ -42,22 +42,19 @@ namespace VSDebugCoreLib.Commands.Memory
             }
         }
 
-        public override void Execute(string text)
+        public override void Execute(string[] args)
         {
-            base.Execute(text);
+            base.Execute(args);
 
-            char[] sp = {' ', '\t'};
-            var argv = text.Split(sp, 3, StringSplitOptions.RemoveEmptyEntries);
-
-            if (argv.Length != 3)
+            if (args.Length != 3)
             {
                 Context.CONSOLE.Write(CommandHelp);
                 return;
             }
 
-            var strArgDst = argv[1];
-            var strArgSize = argv[2];
-            var strArgFile = argv[0];
+            var strArgFile = args[0];
+            var strArgDst = args[1];
+            var strArgSize = args[2];
 
             // get file path
             var strPath = Path.GetDirectoryName(strArgFile);

--- a/VSDebugCoreLib/Commands/Memory/MemAlloc.cs
+++ b/VSDebugCoreLib/Commands/Memory/MemAlloc.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using VSDebugCoreLib.Utils;
 
@@ -39,20 +39,17 @@ namespace VSDebugCoreLib.Commands.Memory
             }
         }
 
-        public override void Execute(string text)
+        public override void Execute(string[] args)
         {
-            base.Execute(text);
+            base.Execute(args);
 
-            char[] sp = {' ', '\t'};
-            var argv = text.Split(sp, 1, StringSplitOptions.RemoveEmptyEntries);
-
-            if (argv.Length != 1)
+            if (args.Length != 1)
             {
                 Context.CONSOLE.Write(CommandHelp);
                 return;
             }
 
-            var strArgSize = argv[0];
+            var strArgSize = args[0];
 
             var varArgSize = Context.IDE.Debugger.GetExpression(strArgSize, false, 100);
             var processId = Context.IDE.Debugger.CurrentProcess.ProcessID;

--- a/VSDebugCoreLib/Commands/Memory/MemCpy.cs
+++ b/VSDebugCoreLib/Commands/Memory/MemCpy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using VSDebugCoreLib.Utils;
 
@@ -41,22 +41,19 @@ namespace VSDebugCoreLib.Commands.Memory
             }
         }
 
-        public override void Execute(string text)
+        public override void Execute(string[] args)
         {
-            base.Execute(text);
+            base.Execute(args);
 
-            char[] sp = {' ', '\t'};
-            var argv = text.Split(sp, 3, StringSplitOptions.RemoveEmptyEntries);
-
-            if (argv.Length != 3)
+            if (args.Length != 3)
             {
                 Context.CONSOLE.Write(CommandHelp);
                 return;
             }
 
-            var strArgDst = argv[0];
-            var strArgSize = argv[2];
-            var strArgSrc = argv[1];
+            var strArgDst = args[0];
+            var strArgSrc = args[1];
+            var strArgSize = args[2];
 
             var varArgDst = Context.IDE.Debugger.GetExpression(strArgDst, false, 100);
             var varArgSrc = Context.IDE.Debugger.GetExpression(strArgSrc, false, 100);

--- a/VSDebugCoreLib/Commands/Memory/MemDiff.cs
+++ b/VSDebugCoreLib/Commands/Memory/MemDiff.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -43,22 +43,19 @@ namespace VSDebugCoreLib.Commands.Memory
             }
         }
 
-        public override void Execute(string text)
+        public override void Execute(string[] args)
         {
-            base.Execute(text);
+            base.Execute(args);
 
-            char[] sp = {' ', '\t'};
-            var argv = text.Split(sp, 3, StringSplitOptions.RemoveEmptyEntries);
-
-            if (argv.Length != 3)
+            if (args.Length != 3)
             {
                 Context.CONSOLE.Write(CommandHelp);
                 return;
             }
 
-            var strArgAddr1 = argv[0];
-            var strArgAddr2 = argv[1];
-            var strArgSize = argv[2];
+            var strArgAddr1 = args[0];
+            var strArgAddr2 = args[1];
+            var strArgSize = args[2];
 
             var varArgAddr1 = Context.IDE.Debugger.GetExpression(strArgAddr1, false, 100);
             var varArgAddr2 = Context.IDE.Debugger.GetExpression(strArgAddr2, false, 100);

--- a/VSDebugCoreLib/Commands/Memory/MemFree.cs
+++ b/VSDebugCoreLib/Commands/Memory/MemFree.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using VSDebugCoreLib.Utils;
 
@@ -39,20 +39,17 @@ namespace VSDebugCoreLib.Commands.Memory
             }
         }
 
-        public override void Execute(string text)
+        public override void Execute(string[] args)
         {
-            base.Execute(text);
+            base.Execute(args);
 
-            char[] sp = {' ', '\t'};
-            var argv = text.Split(sp, 1, StringSplitOptions.RemoveEmptyEntries);
-
-            if (argv.Length != 1)
+            if (args.Length != 1)
             {
                 Context.CONSOLE.Write(CommandHelp);
                 return;
             }
 
-            var strArgAddr = argv[0];
+            var strArgAddr = args[0];
 
             var varArgAddr = Context.IDE.Debugger.GetExpression(strArgAddr, false, 100);
             var processId = Context.IDE.Debugger.CurrentProcess.ProcessID;

--- a/VSDebugCoreLib/Commands/Memory/MemSet.cs
+++ b/VSDebugCoreLib/Commands/Memory/MemSet.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using VSDebugCoreLib.Utils;
 
@@ -41,22 +41,19 @@ namespace VSDebugCoreLib.Commands.Memory
             }
         }
 
-        public override void Execute(string text)
+        public override void Execute(string[] args)
         {
-            base.Execute(text);
+            base.Execute(args);
 
-            char[] sp = {' ', '\t'};
-            var argv = text.Split(sp, 3, StringSplitOptions.RemoveEmptyEntries);
-
-            if (argv.Length != 3)
+            if (args.Length != 3)
             {
                 Context.CONSOLE.Write(CommandHelp);
                 return;
             }
 
-            var strArgDst = argv[0];
-            var strArgSize = argv[2];
-            var strArgVal = argv[1];
+            var strArgDst = args[0];
+            var strArgVal = args[1];
+            var strArgSize = args[2];
 
             var varArgDst = Context.IDE.Debugger.GetExpression(strArgDst, false, 100);
             var varArgVal = Context.IDE.Debugger.GetExpression(strArgVal, false, 100);

--- a/VSDebugCoreLib/Commands/UI/AboutCommand.cs
+++ b/VSDebugCoreLib/Commands/UI/AboutCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using VSDebugCoreLib.UI;
 
 namespace VSDebugCoreLib.Commands.UI
@@ -16,9 +16,9 @@ namespace VSDebugCoreLib.Commands.UI
             new AboutWindow(Context).ShowDialog();
         }
 
-        public override void Execute(string text)
+        public override void Execute(string[] args)
         {
-            base.Execute(text);
+            base.Execute(args);
 
             MenuCallback(this, EventArgs.Empty);
         }

--- a/VSDebugCoreLib/Commands/UI/HelpCommand.cs
+++ b/VSDebugCoreLib/Commands/UI/HelpCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using VSDebugCoreLib.Utils;
 
 namespace VSDebugCoreLib.Commands.UI
@@ -16,14 +16,11 @@ namespace VSDebugCoreLib.Commands.UI
             MiscHelpers.LaunchLink(@"http://" + Resources.HelpWebsite);
         }
 
-        public override void Execute(string text)
+        public override void Execute(string[] args)
         {
-            base.Execute(text);
+            base.Execute(args);
 
-            char[] sp = {' ', '\t'};
-            var argv = text.Split(sp, 2);
-
-            if (1 == argv.Length && argv[0] == string.Empty)
+            if (0 == args.Length)
             {
                 Context.CONSOLE.Write("For more information on a specific command, type help command-name");
                 Context.CONSOLE.WriteSeparator();
@@ -35,9 +32,9 @@ namespace VSDebugCoreLib.Commands.UI
 
                 Context.CONSOLE.WriteSeparator();
             }
-            else if (argv.Length >= 1 && argv[0] != string.Empty)
+            else
             {
-                var command = Context.CONSOLE.FindCommand(argv[0]);
+                var command = Context.CONSOLE.FindCommand(args[0]);
 
                 if (null != command)
                 {
@@ -55,7 +52,7 @@ namespace VSDebugCoreLib.Commands.UI
                 }
                 else
                 {
-                    Context.CONSOLE.Write("Command: " + "<" + argv[0] + ">" + " is not valid.");
+                    Context.CONSOLE.Write("Command: " + "<" + args[0] + ">" + " is not valid.");
                 }
             }
         }

--- a/VSDebugCoreLib/Commands/UI/SettingsCommand.cs
+++ b/VSDebugCoreLib/Commands/UI/SettingsCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using VSDebugCoreLib.UI;
 
 namespace VSDebugCoreLib.Commands.UI
@@ -17,9 +17,9 @@ namespace VSDebugCoreLib.Commands.UI
             new SettingsWindow(Context).ShowDialog();
         }
 
-        public override void Execute(string text)
+        public override void Execute(string[] args)
         {
-            base.Execute(text);
+            base.Execute(args);
 
             MenuCallback(this, EventArgs.Empty);
         }

--- a/VSDebugCoreLib/Properties/Settings.Designer.cs
+++ b/VSDebugCoreLib/Properties/Settings.Designer.cs
@@ -9,20 +9,20 @@
 //------------------------------------------------------------------------------
 
 namespace VSDebugCoreLib.Properties {
-    
-    
+
+
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
-        
+
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-        
+
         public static Settings Default {
             get {
                 return defaultInstance;
             }
         }
-        
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
@@ -34,7 +34,7 @@ namespace VSDebugCoreLib.Properties {
                 this["HexEditor"] = value;
             }
         }
-        
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
@@ -46,7 +46,7 @@ namespace VSDebugCoreLib.Properties {
                 this["TextEditor"] = value;
             }
         }
-        
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
@@ -58,7 +58,7 @@ namespace VSDebugCoreLib.Properties {
                 this["ImgEditor"] = value;
             }
         }
-        
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
@@ -70,7 +70,7 @@ namespace VSDebugCoreLib.Properties {
                 this["WorkingDirectory"] = value;
             }
         }
-        
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
@@ -82,7 +82,7 @@ namespace VSDebugCoreLib.Properties {
                 this["DiffTool"] = value;
             }
         }
-        
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute(@"
@@ -119,12 +119,12 @@ namespace VSDebugCoreLib.Properties {
                 this["ExtensionsMap"] = value;
             }
         }
-        
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("\r\n                    <CAliasMap xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-inst" +
-            "ance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\r\n                        <Va" +
-            "lues />\r\n                    </CAliasMap>\r\n                ")]
+        [global::System.Configuration.DefaultSettingValueAttribute("\n                    <CAliasMap xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-insta" +
+            "nce\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n                        <Valu" +
+            "es />\n                    </CAliasMap>\n                ")]
         public global::VSDebugCoreLib.CAliasMap AliasMap {
             get {
                 return ((global::VSDebugCoreLib.CAliasMap)(this["AliasMap"]));
@@ -133,18 +133,30 @@ namespace VSDebugCoreLib.Properties {
                 this["AliasMap"] = value;
             }
         }
-        
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("\r\n                    <CCmdHistory xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-in" +
-            "stance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\r\n                        <" +
-            "Values />\r\n                    </CCmdHistory>\r\n                ")]
+        [global::System.Configuration.DefaultSettingValueAttribute("\n                    <CCmdHistory xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-ins" +
+            "tance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n                        <Va" +
+            "lues />\n                    </CCmdHistory>\n                ")]
         public global::VSDebugCoreLib.CCmdHistory CmdHistory {
             get {
                 return ((global::VSDebugCoreLib.CCmdHistory)(this["CmdHistory"]));
             }
             set {
                 this["CmdHistory"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int Version {
+            get {
+                return ((int)(this["Version"]));
+            }
+            set {
+                this["Version"] = value;
             }
         }
     }

--- a/VSDebugCoreLib/Properties/Settings.settings
+++ b/VSDebugCoreLib/Properties/Settings.settings
@@ -59,5 +59,8 @@
                     &lt;/CCmdHistory&gt;
                 </Value>
     </Setting>
+    <Setting Name="Version" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/VSDebugCoreLib/SettingsManager.cs
+++ b/VSDebugCoreLib/SettingsManager.cs
@@ -1,8 +1,11 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Configuration;
+using System.Diagnostics;
 using System.IO;
 using VSDebugCoreLib.Properties;
+using VSDebugCoreLib.Utils;
 
 namespace VSDebugCoreLib
 {
@@ -41,14 +44,16 @@ namespace VSDebugCoreLib
         {
         }
 
-        public CAliasMapElement(string alias, string val)
+        public CAliasMapElement(string alias, string val, string[] arguments)
         {
             Alias = alias;
             Value = val;
+            Arguments = arguments;
         }
 
         public string Alias { get; set; }
         public string Value { get; set; }
+        public string[] Arguments { get; set; }
     }
 
     [SettingsSerializeAs(SettingsSerializeAs.Xml)]
@@ -223,13 +228,13 @@ namespace VSDebugCoreLib
 
         public CAliasMap AliasList { get; set; }
 
-        public bool AddAlias(string alias, string value)
+        public bool AddAlias(string alias, string value, string[] args)
         {
             var res = false;
 
             if (null == FindAlias(alias))
             {
-                AliasList.Values.Add(new CAliasMapElement(alias, value));
+                AliasList.Values.Add(new CAliasMapElement(alias, value, args));
                 res = true;
             }
 
@@ -246,13 +251,24 @@ namespace VSDebugCoreLib
             return res;
         }
 
-        public string FindAliasValue(string alias)
+        public string FindAliasCommand(string alias)
         {
             string res = null;
             var item = FindAlias(alias);
 
             if (null != item)
                 res = item.Value;
+
+            return res;
+        }
+
+        public string[] FindAliasArguments(string alias)
+        {
+            string[] res = null;
+            var item = FindAlias(alias);
+
+            if (null != item)
+                res = item.Arguments;
 
             return res;
         }
@@ -324,10 +340,16 @@ namespace VSDebugCoreLib
             VSDSettings.GeneralSettings.Tools.ExtensionsMap = Settings.Default.ExtensionsMap;
             VSDSettings.Alias.AliasList = Settings.Default.AliasMap;
             VSDSettings.CmdHistory = Settings.Default.CmdHistory;
+
+            if (0 == Settings.Default.Version)
+            {
+                UpgradeV0toV1();
+            }
         }
 
         public void SaveSettings()
         {
+            Settings.Default.Version = 1;
             Settings.Default.WorkingDirectory = VSDSettings.GeneralSettings.WorkingDirectory;
             Settings.Default.DiffTool = VSDSettings.GeneralSettings.DiffTool;
             Settings.Default.HexEditor = VSDSettings.GeneralSettings.HexEditor;
@@ -336,8 +358,30 @@ namespace VSDebugCoreLib
             Settings.Default.ExtensionsMap = VSDSettings.GeneralSettings.Tools.ExtensionsMap;
             Settings.Default.AliasMap = VSDSettings.Alias.AliasList;
             Settings.Default.CmdHistory = VSDSettings.CmdHistory;
-
             Settings.Default.Save();
+        }
+
+        private void UpgradeV0toV1()
+        {
+            var aliases = new CAliasMap();
+            foreach (var alias in VSDSettings.Alias.AliasList.Values)
+            {
+                if (null == alias.Arguments)
+                {
+                    try
+                    {
+                        var args = MiscHelpers.ParseCommand(alias.Value);
+                        alias.Value = args[0];
+                        alias.Arguments = MiscHelpers.ShiftArray(args);
+                        aliases.Values.Add(alias);
+                    }
+                    catch (Exception e)
+                    {
+                        Debugger.Log(3, "Warning", "Failed to convert alias <" + alias.Alias + ">: " + e.Message);
+                    }
+                }
+            }
+            VSDSettings.Alias.AliasList = aliases;
         }
     }
 }

--- a/VSDebugCoreLib/Utils/MiscHelpers.cs
+++ b/VSDebugCoreLib/Utils/MiscHelpers.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace VSDebugCoreLib.Utils
@@ -20,6 +21,105 @@ namespace VSDebugCoreLib.Utils
             {
                 // Do nothing if default application handler is not associated.
             }
+        }
+
+        public static T[] ShiftArray<T>(T[] arr, uint count = 1)
+        {
+            if (arr.Length <= count)
+            {
+                return new T[0];
+            }
+
+            var res = new T[arr.Length - count];
+            Array.Copy(arr, count, res, 0, res.Length);
+            return res;
+        }
+
+        public static string[] ParseCommand(string text)
+        {
+            char[] spaces = { ' ', '\t' };
+            char[] stringDelimiter = { '\'', '"' };
+            char[] escapeCharacters = { '\\' };
+
+            var args = new List<string>();
+
+            var currentArg = "";
+            char lastDelimiter = ' ';
+            bool inString = false;
+            bool isEscaped = false;
+            bool endOfString = false;
+
+            foreach (var c in text)
+            {
+                if (isEscaped)
+                {
+                    // escaped, do not do any processing of this character
+                    currentArg += c;
+                    isEscaped = false;
+                    continue;
+                }
+                else if (Array.Exists(escapeCharacters, e => e == c))
+                {
+                    // escape character, skip next
+                    isEscaped = true;
+                    continue;
+                }
+
+                // in a string, we are only interested in end characerts
+                if (inString)
+                {
+                    if (c == lastDelimiter)
+                    {
+                        // end of string
+                        inString = false;
+                        args.Add(currentArg);
+                        currentArg = "";
+                        endOfString = true;
+                    }
+                    else
+                    {
+                        currentArg += c;
+                    }
+                    continue;
+                }
+
+                if (Array.Exists(spaces, e => e == c))
+                {
+                    args.Add(currentArg);
+                    currentArg = "";
+                    endOfString = false;
+                    continue;
+                }
+
+                if (endOfString)
+                {
+                    throw new InvalidOperationException("The given command contains invalid string delimiter.");
+                }
+
+                if (currentArg.Length == 0 && Array.Exists(stringDelimiter, e => e == c))
+                {
+                    // start of new group and a string delimter => handle as a string
+                    inString = true;
+                    lastDelimiter = c;
+                }
+                else
+                {
+                    currentArg += c;
+                }
+            }
+
+            if (isEscaped)
+            {
+                throw new InvalidOperationException("The given command ends with an escape character.");
+            }
+            else if (inString)
+            {
+                throw new InvalidOperationException("The given command contains invalid string delimiter.");
+            }
+
+            args.Add(currentArg);
+
+            return args.FindAll(e => e.Length > 0).ToArray();
         }
     }
 }

--- a/VSDebugCoreLib/app.config
+++ b/VSDebugCoreLib/app.config
@@ -67,6 +67,9 @@
                     </CCmdHistory>
                 </value>
             </setting>
+            <setting name="Version" serializeAs="String">
+                <value>0</value>
+            </setting>
         </VSDebugCoreLib.Properties.Settings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>


### PR DESCRIPTION
Allow string delimitation using `"` or `'`. Added settings migration for existing aliases.